### PR TITLE
feat: ignore custom properties in :root

### DIFF
--- a/lib/rules/declaration-comment-magic-numbers-before/index.js
+++ b/lib/rules/declaration-comment-magic-numbers-before/index.js
@@ -19,9 +19,16 @@ const rule = function(actual) {
 
     root.walkDecls(decl => {
       const value = decl.value;
+      const prop = decl.prop;
+      const parent = decl.parent;
 
       // ignore variables
       if (isVariable(value) || value.startsWith("$")) {
+        return;
+      }
+
+      // ignore custom properties in :root
+      if (prop.startsWith("--") && parent.selector === ":root") {
         return;
       }
 

--- a/lib/rules/declaration-comment-magic-numbers-before/test/index.spec.js
+++ b/lib/rules/declaration-comment-magic-numbers-before/test/index.spec.js
@@ -31,8 +31,16 @@ testRule(rule, {
         width: var(--default-width);
       }
     `,
-      description: "There is comment where only before magic number"
-    }
+      description: "There is comment where only before magic number",
+    },
+    {
+      code: `
+      :root {
+        --spacing: 1rem;
+      }
+    `,
+      description: "custom properties in :root should be ignored",
+    },
   ],
 
   reject: [
@@ -55,7 +63,18 @@ testRule(rule, {
     `,
       line: 3,
       message: messages.expected,
-      description: "There is not comment where before magic number"
-    }
-  ]
+      description: "There is not comment where before magic number",
+    },
+    {
+      code: `
+      body: {
+        --spacing: 2rem;
+      }
+    `,
+      line: 3,
+      message: messages.expected,
+      description:
+        "custom properties in other selectors than :root should not be ignored",
+    },
+  ],
 });


### PR DESCRIPTION
Hi @tyankatsu0105,

thanks for this plugin, it's a really good idea!

I created this PR to ignore custom properties that are set in `:root`. Our usual use case is to set a bunch of custom properties in `:root` like spacings etc., so we would need to allow numbers in there.

Thanks,
Michael